### PR TITLE
Update @TestInstance javadoc with a new use case

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
@@ -51,7 +51,8 @@ import org.apiguardian.api.API;
  * <li>Declaration of {@code @BeforeAll} and {@code @AfterAll} on interface
  * {@code default} methods.</li>
  * <li>Simplified declaration of non-static {@code @BeforeAll} and {@code @AfterAll}
- * methods in test classes implemented with the Kotlin programming language.</li>
+ * methods and also factory methods for {@code @MethodSource} in test classes
+ * implemented with the Kotlin programming language.</li>
  * </ul>
  *
  * <p>{@code @TestInstance} may also be used as a meta-annotation in order to


### PR DESCRIPTION
## Overview

Related Stack Overflow post: [What use is @TestInstance annotation in JUnit 5?](https://stackoverflow.com/a/66185596/8583692)

Add another use case for `TestInstace.PER_CLASS` in Kotlin, which is, using regular simple class methods as the argument producer for `@MethodSource` (which is used for parameterized tests):

```kotlin
@ParameterizedTest
@MethodSource("generateStrings")
fun `Test strings`(argument: String) {
    check(argument.isNotEmpty())
}

private fun generateStrings() = listOf(
    "java",
    "kotlin"
)
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
